### PR TITLE
Fix Build (add option CanCharmNeutral)

### DIFF
--- a/Roles/Neutral/Succubus.cs
+++ b/Roles/Neutral/Succubus.cs
@@ -17,6 +17,7 @@ public static class Succubus
     public static OptionItem KnowTargetRole;
     public static OptionItem TargetKnowOtherTarget;
     public static OptionItem CharmedCountMode;
+    public static OptionItem CanCharmNeutral;
 
     public static readonly string[] charmedCountMode =
     {


### PR DESCRIPTION
Creation of a setting was skipped and this was causing a build error

![image](https://github.com/Loonie-Toons/TOHE-Restored/assets/104814436/cc93d663-835b-4c59-a0b5-12d046909ee6)
