### PR TITLE
Fix guesser show addons

### DIFF
--- a/Modules/CustomRolesHelper.cs
+++ b/Modules/CustomRolesHelper.cs
@@ -1,5 +1,11 @@
 using AmongUs.GameOptions;
+using HarmonyLib;
+using Sentry.Internal;
 using System.Linq;
+using static UnityEngine.GridBrushBase;
+using static UnityEngine.ParticleSystem.PlaybackState;
+using TOHE.Roles.AddOns.Crewmate;
+using TOHE.Roles.AddOns.Impostor;
 
 namespace TOHE;
 
@@ -208,7 +214,6 @@ internal static class CustomRolesHelper
             CustomRoles.Trapper or
             CustomRoles.Brakar or
             CustomRoles.Oblivious or
-            CustomRoles.Guesser or
             CustomRoles.Bewilder or
             CustomRoles.Knighted or
             CustomRoles.Workhorse or
@@ -225,8 +230,6 @@ internal static class CustomRolesHelper
             CustomRoles.Infected or
             CustomRoles.Onbound or
             CustomRoles.Contagious or
-            CustomRoles.Bait or
-            CustomRoles.Trapper or
             CustomRoles.Guesser or
             CustomRoles.Rogue or
             CustomRoles.Unreportable or

--- a/Modules/CustomRolesHelper.cs
+++ b/Modules/CustomRolesHelper.cs
@@ -1,11 +1,5 @@
 using AmongUs.GameOptions;
-using HarmonyLib;
-using Sentry.Internal;
 using System.Linq;
-using static UnityEngine.GridBrushBase;
-using static UnityEngine.ParticleSystem.PlaybackState;
-using TOHE.Roles.AddOns.Crewmate;
-using TOHE.Roles.AddOns.Impostor;
 
 namespace TOHE;
 

--- a/Modules/GuessManager.cs
+++ b/Modules/GuessManager.cs
@@ -1,6 +1,5 @@
 ﻿using HarmonyLib;
 using Hazel;
-using Rewired.UI.ControlMapper;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -94,6 +93,9 @@ public static class GuessManager
         if (CheckCommond(ref msg, "id|guesslist|gl编号|玩家编号|玩家id|id列表|玩家列表|列表|所有id|全部id")) operate = 1;
         else if (CheckCommond(ref msg, "shoot|guess|bet|st|gs|bt|猜|赌", false)) operate = 2;
         else return false;
+
+        Logger.Msg(msg, "Msg Guesser");
+        Logger.Msg($"{operate}", "Operate");
 
         if (!pc.IsAlive())
         {
@@ -197,49 +199,104 @@ public static class GuessManager
                     else pc.ShowPopUp(GetString("EGGuessSnitchTaskDone"));
                     return true;
                 }
-                 if (role.IsAdditionRole() && !Options.CanGuessAddons.GetBool() && Options.GuesserMode.GetBool())
-                {
-                    if (!isUI) Utils.SendMessage(GetString("GuessAdtRole"), pc.PlayerId);
-                    else pc.ShowPopUp(GetString("GuessAdtRole"));
-                    return true;
 
+                // Guesser Mode Can/Cant Guess Addons
+                if (Options.GuesserMode.GetBool())
+                {
+                    // Impostors Cant Guess Addons
+                    if (role.IsAdditionRole() && !Options.CanGuessAddons.GetBool() && (Options.ImpostorsCanGuess.GetBool() && pc.Is(CustomRoleTypes.Impostor)))
+                    {
+                        if (!isUI) Utils.SendMessage(GetString("GuessAdtRole"), pc.PlayerId);
+                        else pc.ShowPopUp(GetString("GuessAdtRole"));
+                        return true;
+                    }
+
+                    // Crewmates Cant Guess Addons
+                    if (role.IsAdditionRole() && !Options.CanGuessAddons.GetBool() && (Options.CrewmatesCanGuess.GetBool() && pc.Is(CustomRoleTypes.Crewmate)))
+                    {
+                        if (!isUI) Utils.SendMessage(GetString("GuessAdtRole"), pc.PlayerId);
+                        else pc.ShowPopUp(GetString("GuessAdtRole"));
+                        return true;
+                    }
+
+                    // Neutrals Cant Guess Addons
+                    if (role.IsAdditionRole() && !Options.CanGuessAddons.GetBool() && (Options.NeutralKillersCanGuess.GetBool() || Options.PassiveNeutralsCanGuess.GetBool()) && pc.Is(CustomRoleTypes.Neutral))
+                    {
+                        if (!isUI) Utils.SendMessage(GetString("GuessAdtRole"), pc.PlayerId);
+                        else pc.ShowPopUp(GetString("GuessAdtRole"));
+                        return true;
+                    }
+
+                    // Guesser Mode Can Guess Addons
+                    if (Options.CanGuessAddons.GetBool() && (pc.Is(CustomRoles.EvilGuesser) || pc.Is(CustomRoles.NiceGuesser) || pc.Is(CustomRoles.Guesser)))
+                    {
+                        // Evil Guesser Cant Guess Addons
+                        if (role.IsAdditionRole() && (pc.Is(CustomRoles.EvilGuesser) && !Options.EGCanGuessAdt.GetBool()))
+                        {
+                            if (!isUI) Utils.SendMessage(GetString("GuessAdtRole"), pc.PlayerId);
+                            else pc.ShowPopUp(GetString("GuessAdtRole"));
+                            return true;
+                        }
+
+                        // Nice Guesser Cant Guess Addons
+                        if (role.IsAdditionRole() && (pc.Is(CustomRoles.NiceGuesser) && !Options.GGCanGuessAdt.GetBool()))
+                        {
+                            if (!isUI) Utils.SendMessage(GetString("GuessAdtRole"), pc.PlayerId);
+                            else pc.ShowPopUp(GetString("GuessAdtRole"));
+                            return true;
+                        }
+
+                        // Guesser (add-on) Cant Guess Addons
+                        if (role.IsAdditionRole() && (pc.Is(CustomRoles.Guesser) && !Options.GCanGuessAdt.GetBool()))
+                        {
+                            if (!isUI) Utils.SendMessage(GetString("GuessAdtRole"), pc.PlayerId);
+                            else pc.ShowPopUp(GetString("GuessAdtRole"));
+                            return true;
+                        }
+                    }
                 }
-                 if (role.IsImpostor() && !Options.ImpCanGuessImp.GetBool() && pc.Is(CustomRoleTypes.Impostor) && Options.GuesserMode.GetBool())
+                // Guesser Mode Off, Cant Guess Addon
+                else
+                {
+                    // Evil Guesser Cant Guess Addons
+                    if (role.IsAdditionRole() && pc.Is(CustomRoles.EvilGuesser) && !Options.EGCanGuessAdt.GetBool())
+                    {
+                        if (!isUI) Utils.SendMessage(GetString("GuessAdtRole"), pc.PlayerId);
+                        else pc.ShowPopUp(GetString("GuessAdtRole"));
+                        return true;
+                    }
+
+                    // Nice Guesser Cant Guess Addons
+                    else if (role.IsAdditionRole() && pc.Is(CustomRoles.NiceGuesser) && !Options.GGCanGuessAdt.GetBool())
+                    {
+                        if (!isUI) Utils.SendMessage(GetString("GuessAdtRole"), pc.PlayerId);
+                        else pc.ShowPopUp(GetString("GuessAdtRole"));
+                        return true;
+                    }
+
+                    // Guesser (add-on) Cant Guess Addons
+                    else if (role.IsAdditionRole() && pc.Is(CustomRoles.Guesser) && !Options.GCanGuessAdt.GetBool())
+                    {
+                        if (!isUI) Utils.SendMessage(GetString("GuessAdtRole"), pc.PlayerId);
+                        else pc.ShowPopUp(GetString("GuessAdtRole"));
+                        return true;
+                    }
+                }
+
+                if (role.IsImpostor() && !Options.ImpCanGuessImp.GetBool() && target.Is(CustomRoleTypes.Impostor) && Options.GuesserMode.GetBool())
                 {
                     if (!isUI) Utils.SendMessage(GetString("GuessImpRole"), pc.PlayerId);
                     else pc.ShowPopUp(GetString("GuessImpRole"));
                     return true;
 
                 }
-                 if (role.IsCrewmate() && !Options.CrewCanGuessCrew.GetBool() && pc.Is(CustomRoleTypes.Crewmate) && Options.GuesserMode.GetBool())
+                if (role.IsCrewmate() && !Options.CrewCanGuessCrew.GetBool() && target.Is(CustomRoleTypes.Crewmate) && Options.GuesserMode.GetBool())
                 {
                     if (!isUI) Utils.SendMessage(GetString("GuessCrewRole"), pc.PlayerId);
                     else pc.ShowPopUp(GetString("GuessCrewRole"));
                     return true;
 
                 }
-           /*     if (role.IsAdditionRole())
-                {
-                    if (
-                        (
-                            (pc.Is(CustomRoles.NiceGuesser) && !Options.GGCanGuessAdt.GetBool()) ||
-                            (pc.Is(CustomRoles.EvilGuesser) && !Options.EGCanGuessAdt.GetBool()) ||
-                            (pc.Is(CustomRoles.Guesser) && !Options.GCanGuessAdt.GetBool()) ||
-                            (
-                                (
-                                    Options.CrewmatesCanGuess.GetBool() ||
-                                    Options.ImpostorsCanGuess.GetBool() ||
-                                    Options.NeutralKillersCanGuess.GetBool() ||
-                                    Options.PassiveNeutralsCanGuess.GetBool()
-                                ) && (!Options.CanGuessAddons.GetBool() && role is not CustomRoles.Infected || role is not CustomRoles.Workhorse || role is not CustomRoles.Madmate || role is not CustomRoles.Charmed || role is not CustomRoles.Egoist)
-                            )
-                        )
-                    )
-                    {
-                        Utils.SendMessage(GetString("GuessAdtRole"), pc.PlayerId);
-                        return true;
-                    }
-                } */
 
                 if (pc.PlayerId == target.PlayerId)
                 {
@@ -247,13 +304,25 @@ public static class GuessManager
                     else pc.ShowPopUp(Utils.ColorString(Color.cyan, GetString("MessageFromKPD")) + "\n" + GetString("LaughToWhoGuessSelf"));
                     guesserSuicide = true;
                 }
-                else if (pc.Is(CustomRoles.NiceGuesser) && role.IsCrewmate() && !Options.GGCanGuessCrew.GetBool() && !pc.Is(CustomRoles.Madmate)) guesserSuicide = true;
-                else if (pc.Is(CustomRoles.EvilGuesser) && role.IsImpostor() && !Options.EGCanGuessImp.GetBool()) guesserSuicide = true;
-              //  else if (pc.Is(CustomRoles.Guesser)/* && role.IsImpostor() && !Options.GCanGuessImp.GetBool()*/) guesserSuicide = true;
-             //   else if (pc.Is(CustomRoles.Guesser)/* && role.IsCrewmate() && !pc.Is(CustomRoles.Madmate) && !Options.GCanGuessCrew.GetBool() */) guesserSuicide = true;
-                else if (!target.Is(role)) guesserSuicide = true;
+                else if (pc.Is(CustomRoles.NiceGuesser) && target.Is(CustomRoleTypes.Crewmate) && !Options.GGCanGuessCrew.GetBool() && !pc.Is(CustomRoles.Madmate)) 
+                { 
+                    guesserSuicide = true; 
+                    Logger.Msg($"{guesserSuicide}", "guesserSuicide1"); 
+                }
+                else if (pc.Is(CustomRoles.EvilGuesser) && target.Is(CustomRoleTypes.Impostor) && !Options.EGCanGuessImp.GetBool()) 
+                { 
+                    guesserSuicide = true; 
+                    Logger.Msg($"{guesserSuicide}", "guesserSuicide2"); 
+                }
+                //  else if (pc.Is(CustomRoles.Guesser)/* && role.IsImpostor() && !Options.GCanGuessImp.GetBool()*/) guesserSuicide = true;
+                //   else if (pc.Is(CustomRoles.Guesser)/* && role.IsCrewmate() && !pc.Is(CustomRoles.Madmate) && !Options.GCanGuessCrew.GetBool() */) guesserSuicide = true;
+                else if (!target.Is(role)) 
+                { 
+                    guesserSuicide = true; 
+                    Logger.Msg($"{guesserSuicide}", "guesserSuicide3"); 
+                }
 
-                Logger.Info($"{pc.GetNameWithRole()} 猜测了 {target.GetNameWithRole()}", "Guesser");
+                Logger.Info($"{pc.GetNameWithRole()} guessed {target.GetNameWithRole()}", "Guesser");
 
                 var dp = guesserSuicide ? pc : target;
                 target = dp;
@@ -490,7 +559,13 @@ public static class GuessManager
             }
             else
             {
-                if (PlayerControl.LocalPlayer.GetCustomRole() is CustomRoles.NiceGuesser or CustomRoles.EvilGuesser or CustomRoles.Guesser && PlayerControl.LocalPlayer.IsAlive())
+                if (PlayerControl.LocalPlayer.IsAlive() && PlayerControl.LocalPlayer.Is(CustomRoles.EvilGuesser))
+                    CreateGuesserButton(__instance);
+
+                if (PlayerControl.LocalPlayer.IsAlive() && PlayerControl.LocalPlayer.Is(CustomRoles.NiceGuesser))
+                    CreateGuesserButton(__instance);
+
+                if (PlayerControl.LocalPlayer.IsAlive() && PlayerControl.LocalPlayer.Is(CustomRoles.Guesser))
                     CreateGuesserButton(__instance);
             }
         }
@@ -714,9 +789,15 @@ public static class GuessManager
             int ind = 0;
             foreach (CustomRoles role in Enum.GetValues(typeof(CustomRoles)))
             {
-                if (role.IsVanilla() || role.IsAdditionRole() && !Options.CanGuessAddons.GetBool() ||
-                    role is CustomRoles.GM or CustomRoles.NotAssigned or CustomRoles.KB_Normal or CustomRoles.Marshall or CustomRoles.Paranoia or CustomRoles.SuperStar
+                if (role.IsVanilla() || 
+                    role is CustomRoles.GM 
+                    or CustomRoles.NotAssigned 
+                    or CustomRoles.KB_Normal 
+                    or CustomRoles.Marshall 
+                    or CustomRoles.Paranoia 
+                    or CustomRoles.SuperStar
                     ) continue;
+
                 CreateRole(role);
             }
             void CreateRole(CustomRoles role)
@@ -807,8 +888,16 @@ public static class GuessManager
     }
     public static void ReceiveRPC(MessageReader reader, PlayerControl pc)
     {
+        Logger.Msg($"{reader}", "MessageReader reader");
+        Logger.Msg($"{pc}", "PlayerControl pc");
+
         int PlayerId = reader.ReadInt32();
-        CustomRoles role = (CustomRoles)reader.ReadByte();
+        Logger.Msg($"{PlayerId}", "Player Id");
+
+        CustomRoles role = (CustomRoles)reader.ReadUInt32();
+        Logger.Msg($"{role}", "Role UInt32");
+        Logger.Msg($"{GetString(role.ToString())}", "Role String");
+
         GuesserMsg(pc, $"/bt {PlayerId} {GetString(role.ToString())}", true);
     }
 }

--- a/Patches/CredentialsPatch.cs
+++ b/Patches/CredentialsPatch.cs
@@ -51,7 +51,7 @@ internal class VersionShowerStartPatch
 
     private static void Postfix(VersionShower __instance)
     {
-        Main.credentialsText = $"\r\n<color={Main.ModColor}>{Main.ModName}</color> v{Main.PluginVersion} Pre-release 3";
+        Main.credentialsText = $"\r\n<color={Main.ModColor}>{Main.ModName}</color> v{Main.PluginVersion} Pre-release 5";
     //    Main.credentialsText = $"\r\n<color=#de56fd>TOHE SolarLoonieEdit</color> v{Main.PluginVersion}";
         if (Main.IsAprilFools) Main.credentialsText = $"\r\n<color=#00bfff>Town Of Host</color> v11.45.14";
 #if DEBUG


### PR DESCRIPTION
1. Fixed bug where Evil/Nice Guessers could guess add-ons even when the "Can Guess Add-Ons" setting was off
2. Fixed bug cant that show Evil/Nice Guessers from seeing the list of Add-ons they can guess when Guesser Mode was turned off
3. Fixed a bug when Nice Guesser can't guess add-ons Mimic and Stealer