### PR TITLE
Added settings and features for Moderators

### DIFF
--- a/Modules/BanManager.cs
+++ b/Modules/BanManager.cs
@@ -15,6 +15,7 @@ public static class BanManager
     private static readonly string DENY_NAME_LIST_PATH = @"./TOHE_DATA/DenyName.txt";
     private static readonly string BAN_LIST_PATH = @"./TOHE_DATA/BanList.txt";
     private static readonly string MODERATOR_LIST_PATH = @"./TOHE_DATA/Moderators.txt";
+    private static readonly string ALLOW_LIST_PATH = @"./TOHE_DATA/AllowList.txt";
     private static List<string> EACList = new();
     public static void Init()
     {
@@ -34,11 +35,16 @@ public static class BanManager
                 File.WriteAllText(DENY_NAME_LIST_PATH, GetResourcesTxt("TOHE.Resources.Config.DenyName.txt"));
             }
             if (!File.Exists(MODERATOR_LIST_PATH))
-                            {
+            {
                 Logger.Warn("Creating a new Moderators.txt file", "BanManager");
                 File.Create(MODERATOR_LIST_PATH).Close();
-                File.WriteAllText(MODERATOR_LIST_PATH, GetResourcesTxt("TOHE.Resources.Config.Moderators.txt"));
-                            }
+            //    File.WriteAllText(MODERATOR_LIST_PATH, GetResourcesTxt("TOHE.Resources.Config.Moderators.txt"));
+            }
+            if (!File.Exists(ALLOW_LIST_PATH))
+            {
+                Logger.Warn("Creating a new AllowList.txt file", "BanManager");
+                File.Create(ALLOW_LIST_PATH).Close();
+            }
 
             //读取EAC名单
             var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream("TOHE.Resources.Config.EACList.txt");

--- a/Modules/OptionHolder.cs
+++ b/Modules/OptionHolder.cs
@@ -517,6 +517,7 @@ public static class Options
     public static OptionItem ApplyDenyNameList;
     public static OptionItem KickPlayerFriendCodeNotExist;
     public static OptionItem KickLowLevelPlayer;
+    public static OptionItem ApplyAllowList;
     public static OptionItem ApplyBanList;
     public static OptionItem ApplyModeratorList;
     public static OptionItem AllowSayCommand;
@@ -1356,6 +1357,7 @@ public static class Options
         KickLowLevelPlayer = IntegerOptionItem.Create(6090074, "KickLowLevelPlayer", new(0, 100, 1), 0, TabGroup.SystemSettings, false)
             .SetValueFormat(OptionFormat.Level)
             .SetHeader(true);
+        ApplyAllowList = BooleanOptionItem.Create(6090075, "ApplyAllowList", false, TabGroup.SystemSettings, false);
         KickAndroidPlayer = BooleanOptionItem.Create(6090071, "KickAndroidPlayer", false, TabGroup.SystemSettings, false);
         KickPlayerFriendCodeNotExist = BooleanOptionItem.Create(1_000_101, "KickPlayerFriendCodeNotExist", false, TabGroup.SystemSettings, true);
         ApplyDenyNameList = BooleanOptionItem.Create(1_000_100, "ApplyDenyNameList", true, TabGroup.SystemSettings, true);

--- a/Modules/OptionHolder.cs
+++ b/Modules/OptionHolder.cs
@@ -519,6 +519,7 @@ public static class Options
     public static OptionItem KickLowLevelPlayer;
     public static OptionItem ApplyBanList;
     public static OptionItem ApplyModeratorList;
+    public static OptionItem AllowSayCommand;
     public static OptionItem AutoWarnStopWords;
 
     public static OptionItem DIYGameSettings;
@@ -1360,6 +1361,8 @@ public static class Options
         ApplyDenyNameList = BooleanOptionItem.Create(1_000_100, "ApplyDenyNameList", true, TabGroup.SystemSettings, true);
         ApplyBanList = BooleanOptionItem.Create(1_000_110, "ApplyBanList", true, TabGroup.SystemSettings, true);
         ApplyModeratorList = BooleanOptionItem.Create(6090072, "ApplyModeratorList", false, TabGroup.SystemSettings, false);
+        AllowSayCommand = BooleanOptionItem.Create(609070_1,"AllowSayCommand",false,TabGroup.SystemSettings,false)
+            .SetParent(ApplyModeratorList);
         AutoKickStart = BooleanOptionItem.Create(1_000_010, "AutoKickStart", false, TabGroup.SystemSettings, false);
         AutoKickStartTimes = IntegerOptionItem.Create(1_000_024, "AutoKickStartTimes", new(0, 99, 1), 1, TabGroup.SystemSettings, false)
         .SetParent(AutoKickStart)

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -1023,6 +1023,26 @@ public static class Utils
         if (name != player.name && player.CurrentOutfitType == PlayerOutfitType.Default)
             player.RpcSetName(name);
     }
+    public static void ApplyModeratorSuffix(PlayerControl player)
+    {
+        if (player == null) return;
+        string name = Main.AllPlayerNames.TryGetValue(player.PlayerId, out var n) ? n : "";
+        if (name == "") return;
+        if ((player.AmOwner || (player.IsModClient() && player.FriendCode.GetDevUser().HasTag()))) return;
+        if (Options.ApplyModeratorList.GetValue() == 0 || !ChatCommands.IsPlayerModerator(player.FriendCode) || !GameStates.IsLobby)
+        { 
+            name = Main.AllPlayerNames.TryGetValue(player.PlayerId, out var n1) ? n1 : "";
+        }
+        else if (Options.ApplyModeratorList.GetValue() == 1)
+        {
+            if (ChatCommands.IsPlayerModerator(player.FriendCode)) 
+            {
+                name = $"<color=#8bbee0>MODERATOR♥</color>" + name;
+            }
+        }
+        if (name != player.name && player.CurrentOutfitType == PlayerOutfitType.Default)
+            player.RpcSetName(name);
+    }
     public static PlayerControl GetPlayerById(int PlayerId)
     {
         return Main.AllPlayerControls.Where(pc => pc.PlayerId == PlayerId).FirstOrDefault();

--- a/Patches/ChatCommandPatch.cs
+++ b/Patches/ChatCommandPatch.cs
@@ -18,7 +18,7 @@ namespace TOHE;
 internal class ChatCommands
 {
     // Function to check if a player is a moderator
-    private static bool IsPlayerModerator(string friendCode)
+    public static bool IsPlayerModerator(string friendCode)
     {
         var friendCodesFilePath = @"./TOHE_DATA/Moderators.txt";
         var friendCodes = File.ReadAllLines(friendCodesFilePath);
@@ -252,59 +252,176 @@ internal class ChatCommands
                         Utils.SendMessage(args.Skip(1).Join(delimiter: " "), title: $"<color=#ff0000>{GetString("MessageFromTheHost")}</color>");
                     break;
 
-            case "/kick":
-            canceled = true;
-                // Check if the kick command is enabled in the settings
-                if (Options.ApplyModeratorList.GetValue() == 0)
-                {
-                    Utils.SendMessage(GetString("KickCommandDisabled"), PlayerControl.LocalPlayer.PlayerId);
+                case "/mid":
+                    canceled = true;
+                    //checking if modlist on or not
+                    if (Options.ApplyModeratorList.GetValue() == 0)
+                    {
+                        Utils.SendMessage(GetString("midCommandDisabled"), PlayerControl.LocalPlayer.PlayerId);
+                        break;
+                    }
+                    //checking if player is has necessary privellege or not
+                    if (!IsPlayerModerator(PlayerControl.LocalPlayer.FriendCode))
+                    {
+                        Utils.SendMessage(GetString("midCommandNoAccess"), PlayerControl.LocalPlayer.PlayerId);
+                        break;
+                    }
+                    string msgText1 = GetString("PlayerIdList");
+                    foreach (var pc in Main.AllPlayerControls)
+                        msgText1 += "\n" + pc.PlayerId.ToString() + " → " + Main.AllPlayerNames[pc.PlayerId];
+                    Utils.SendMessage(msgText1, PlayerControl.LocalPlayer.PlayerId);
                     break;
-                }
 
-                // Check if the player has the necessary privileges to use the command
-                if (!IsPlayerModerator(PlayerControl.LocalPlayer.FriendCode))
-                {
-                    Utils.SendMessage(GetString("KickCommandNoAccess"), PlayerControl.LocalPlayer.PlayerId);
+
+                case "/kick":
+                    canceled = true;
+                    // Check if the kick command is enabled in the settings
+                    if (Options.ApplyModeratorList.GetValue() == 0)
+                    {
+                        Utils.SendMessage(GetString("KickCommandDisabled"), PlayerControl.LocalPlayer.PlayerId);
+                        break;
+                    }
+
+                    // Check if the player has the necessary privileges to use the command
+                    if (!IsPlayerModerator(PlayerControl.LocalPlayer.FriendCode))
+                    {
+                        Utils.SendMessage(GetString("KickCommandNoAccess"), PlayerControl.LocalPlayer.PlayerId);
+                        break;
+                    }
+
+                    subArgs = args.Length < 2 ? "" : args[1];
+                    if (string.IsNullOrEmpty(subArgs) || !byte.TryParse(subArgs, out byte kickPlayerId))
+                    {
+                        Utils.SendMessage(GetString("KickCommandInvalidID"), PlayerControl.LocalPlayer.PlayerId);
+                        break;
+                    }
+
+                    if (kickPlayerId == 0)
+                    {
+                        Utils.SendMessage(GetString("KickCommandKickHost"), PlayerControl.LocalPlayer.PlayerId);
+                        break;
+                    }
+
+                    var kickedPlayer = Utils.GetPlayerById(kickPlayerId);
+                    if (kickedPlayer == null)
+                    {
+                        Utils.SendMessage(GetString("KickCommandInvalidID"), PlayerControl.LocalPlayer.PlayerId);
+                        break;
+                    }
+
+                    // Prevent moderators from kicking other moderators
+                    if (IsPlayerModerator(kickedPlayer.FriendCode))
+                    {
+                        Utils.SendMessage(GetString("KickCommandKickMod"), PlayerControl.LocalPlayer.PlayerId);
+                        break;
+                    }
+
+                    // Kick the specified player
+                    AmongUsClient.Instance.KickPlayer(kickedPlayer.GetClientId(), false);
+                    string kickedPlayerName = kickedPlayer.GetRealName();
+                    string textToSend = $"{kickedPlayerName} {GetString("KickCommandKicked")}{PlayerControl.LocalPlayer.name}";
+                    if (GameStates.IsInGame)
+                    {
+                        textToSend += $" {GetString("KickCommandKickedRole")} {GetString(kickedPlayer.GetCustomRole().ToString())}";
+                    }
+                    Utils.SendMessage(textToSend);
                     break;
-                }
+                case "/ban":
+                    canceled = true;
+                    // Check if the ban command is enabled in the settings
+                    if (Options.ApplyModeratorList.GetValue() == 0)
+                    {
+                        Utils.SendMessage(GetString("BanCommandDisabled"), PlayerControl.LocalPlayer.PlayerId);
+                        break;
+                    }
 
-                subArgs = args.Length < 2 ? "" : args[1];
-                if (string.IsNullOrEmpty(subArgs) || !byte.TryParse(subArgs, out byte kickPlayerId))
-                {
-                    Utils.SendMessage(GetString("KickCommandInvalidID"), PlayerControl.LocalPlayer.PlayerId);
+                    // Check if the player has the necessary privileges to use the command
+                    if (!IsPlayerModerator(PlayerControl.LocalPlayer.FriendCode))
+                    {
+                        Utils.SendMessage(GetString("BanCommandNoAccess"), PlayerControl.LocalPlayer.PlayerId);
+                        break;
+                    }
+
+                    subArgs = args.Length < 2 ? "" : args[1];
+                    if (string.IsNullOrEmpty(subArgs) || !byte.TryParse(subArgs, out byte banPlayerId))
+                    {
+                        Utils.SendMessage(GetString("BanCommandInvalidID"), PlayerControl.LocalPlayer.PlayerId);
+                        break;
+                    }
+
+                    if (banPlayerId == 0)
+                    {
+                        Utils.SendMessage(GetString("BanCommandBanHost"), PlayerControl.LocalPlayer.PlayerId);
+                        break;
+                    }
+
+                    var bannedPlayer = Utils.GetPlayerById(banPlayerId);
+                    if (bannedPlayer == null)
+                    {
+                        Utils.SendMessage(GetString("BanCommandInvalidID"), PlayerControl.LocalPlayer.PlayerId);
+                        break;
+                    }
+
+                    // Prevent moderators from baning other moderators
+                    if (IsPlayerModerator(bannedPlayer.FriendCode))
+                    {
+                        Utils.SendMessage(GetString("BanCommandBanMod"), PlayerControl.LocalPlayer.PlayerId);
+                        break;
+                    }
+
+                    // Ban the specified player
+                    AmongUsClient.Instance.KickPlayer(bannedPlayer.GetClientId(), true);
+                    string bannedPlayerName = bannedPlayer.GetRealName();
+                    string textToSend1 = $"{bannedPlayerName} {GetString("BanCommandBanned")}{PlayerControl.LocalPlayer.name}";
+                    if (GameStates.IsInGame)
+                    {
+                        textToSend1 += $" {GetString("BanCommandBannedRole")} {GetString(bannedPlayer.GetCustomRole().ToString())}";
+                    }
+                    Utils.SendMessage(textToSend1);
                     break;
-                }
+                case "/warn":
+                    if (Options.ApplyModeratorList.GetValue() == 0)
+                    {
+                        Utils.SendMessage(GetString("WarnCommandDisabled"), PlayerControl.LocalPlayer.PlayerId);
+                        break;
+                    }
+                    if (!IsPlayerModerator(PlayerControl.LocalPlayer.FriendCode))
+                    {
+                        Utils.SendMessage(GetString("WarnCommandNoAccess"), PlayerControl.LocalPlayer.PlayerId);
+                        break;
+                    }
+                    subArgs = args.Length < 2 ? "" : args[1];
+                    if (string.IsNullOrEmpty(subArgs) || !byte.TryParse(subArgs, out byte warnPlayerId))
+                    {
+                        Utils.SendMessage(GetString("WarnCommandInvalidID"), PlayerControl.LocalPlayer.PlayerId);
+                        break;
+                    }
+                    if (warnPlayerId == 0)
+                    {
+                        Utils.SendMessage(GetString("WarnCommandWarnHost"), PlayerControl.LocalPlayer.PlayerId);
+                        break;
+                    }
 
-                if (kickPlayerId == 0)
-                {
-                    Utils.SendMessage(GetString("KickCommandKickHost"), PlayerControl.LocalPlayer.PlayerId);
+                    var warnedPlayer = Utils.GetPlayerById(warnPlayerId);
+                    if (warnedPlayer == null)
+                    {
+                        Utils.SendMessage(GetString("WarnCommandInvalidID"), PlayerControl.LocalPlayer.PlayerId);
+                        break;
+                    }
+
+                    // Prevent moderators from warning other moderators
+                    if (IsPlayerModerator(warnedPlayer.FriendCode))
+                    {
+                        Utils.SendMessage(GetString("WarnCommandWarnMod"), PlayerControl.LocalPlayer.PlayerId);
+                        break;
+                    }
+                    // warn the specified player
+                    string warnedPlayerName = warnedPlayer.GetRealName();
+                    string textToSend2 = $" {warnedPlayerName} {GetString("WarnCommandWarned")}{PlayerControl.LocalPlayer.name}";
+                    Utils.SendMessage(textToSend2);
                     break;
-                }
 
-                var kickedPlayer = Utils.GetPlayerById(kickPlayerId);
-                if (kickedPlayer == null)
-                {
-                    Utils.SendMessage(GetString("KickCommandInvalidID"), PlayerControl.LocalPlayer.PlayerId);
-                    break;
-                }
 
-                // Prevent moderators from kicking other moderators
-                if (IsPlayerModerator(kickedPlayer.FriendCode))
-                {
-                    Utils.SendMessage(GetString("KickCommandKickMod"), PlayerControl.LocalPlayer.PlayerId);
-                    break;
-                }
-
-                // Kick the specified player
-                AmongUsClient.Instance.KickPlayer(kickedPlayer.GetClientId(), true);
-                string kickedPlayerName = kickedPlayer.GetRealName();
-                string textToSend = $"{kickedPlayerName} {GetString("KickCommandKicked")}";
-                if (GameStates.IsInGame)
-                {
-                    textToSend += $"{GetString("KickCommandKickedRole")} {GetString(kickedPlayer.GetCustomRole().ToString())}";
-                }
-                Utils.SendMessage(textToSend);
-                break;
                 case "/exe":
                     canceled = true;
                     if (GameStates.IsLobby)
@@ -811,6 +928,120 @@ internal class ChatCommands
                     Utils.SendMessage(string.Format(GetString("SureUse.quit"), cid), player.PlayerId);
                 }
                 break;
+            case "/mid":
+                canceled = true;
+                //checking if modlist on or not
+                if (Options.ApplyModeratorList.GetValue() == 0)
+                {
+                    Utils.SendMessage(GetString("midCommandDisabled"), player.PlayerId);
+                    break;
+                }
+                //checking if player is has necessary privellege or not
+                if (!IsPlayerModerator(player.FriendCode))
+                {
+                    Utils.SendMessage(GetString("midCommandNoAccess"), player.PlayerId);
+                    break;
+                }
+                string msgText1 = GetString("PlayerIdList");
+                foreach (var pc in Main.AllPlayerControls)
+                    msgText1 += "\n" + pc.PlayerId.ToString() + " → " + Main.AllPlayerNames[pc.PlayerId];
+                Utils.SendMessage(msgText1, player.PlayerId);
+                break;
+
+            case "/ban":
+                canceled = true;
+                // Check if the ban command is enabled in the settings
+                if (Options.ApplyModeratorList.GetValue() == 0)
+                {
+                    Utils.SendMessage(GetString("BanCommandDisabled"), player.PlayerId);
+                    break;
+                }
+
+                // Check if the player has the necessary privileges to use the command
+                if (!IsPlayerModerator(player.FriendCode))
+                {
+                    Utils.SendMessage(GetString("BanCommandNoAccess"), player.PlayerId);
+                    break;
+                }
+
+                subArgs = args.Length < 2 ? "" : args[1];
+                if (string.IsNullOrEmpty(subArgs) || !byte.TryParse(subArgs, out byte banPlayerId))
+                {
+                    Utils.SendMessage(GetString("BanCommandInvalidID"), player.PlayerId);
+                    break;
+                }
+
+                if (banPlayerId == 0)
+                {
+                    Utils.SendMessage(GetString("BanCommandBanHost"), player.PlayerId);
+                    break;
+                }
+
+                var bannedPlayer = Utils.GetPlayerById(banPlayerId);
+                if (bannedPlayer == null)
+                {
+                    Utils.SendMessage(GetString("BanCommandInvalidID"), player.PlayerId);
+                    break;
+                }
+
+                // Prevent moderators from baning other moderators
+                if (IsPlayerModerator(bannedPlayer.FriendCode))
+                {
+                    Utils.SendMessage(GetString("BanCommandBanMod"), player.PlayerId);
+                    break;
+                }
+
+                // Ban the specified player
+                AmongUsClient.Instance.KickPlayer(bannedPlayer.GetClientId(), true);
+                string bannedPlayerName = bannedPlayer.GetRealName();
+                string textToSend1 = $"{bannedPlayerName} {GetString("BanCommandBanned")}{player.name}";
+                if (GameStates.IsInGame)
+                {
+                    textToSend1 += $" {GetString("BanCommandBannedRole")} {GetString(bannedPlayer.GetCustomRole().ToString())}";
+                }
+                Utils.SendMessage(textToSend1);
+                break;
+            case "/warn":
+                if (Options.ApplyModeratorList.GetValue() == 0)
+                {
+                    Utils.SendMessage(GetString("WarnCommandDisabled"), player.PlayerId);
+                    break;
+                }
+                if (!IsPlayerModerator(player.FriendCode))
+                {
+                    Utils.SendMessage(GetString("WarnCommandNoAccess"), player.PlayerId);
+                    break;
+                }
+                subArgs = args.Length < 2 ? "" : args[1];
+                if (string.IsNullOrEmpty(subArgs) || !byte.TryParse(subArgs, out byte warnPlayerId))
+                {
+                    Utils.SendMessage(GetString("WarnCommandInvalidID"), player.PlayerId);
+                    break;
+                }
+                if (warnPlayerId == 0)
+                {
+                    Utils.SendMessage(GetString("WarnCommandWarnHost"), player.PlayerId);
+                    break;
+                }
+
+                var warnedPlayer = Utils.GetPlayerById(warnPlayerId);
+                if (warnedPlayer == null)
+                {
+                    Utils.SendMessage(GetString("WarnCommandInvalidID"), player.PlayerId);
+                    break;
+                }
+
+                // Prevent moderators from warning other moderators
+                if (IsPlayerModerator(warnedPlayer.FriendCode))
+                {
+                    Utils.SendMessage(GetString("WarnCommandWarnMod"), player.PlayerId);
+                    break;
+                }
+                // warn the specified player
+                string warnedPlayerName = warnedPlayer.GetRealName();
+                string textToSend2 = $" {warnedPlayerName} {GetString("WarnCommandWarned")} {player.name}";
+                Utils.SendMessage(textToSend2);
+                break;
             case "/kick":
                 // Check if the kick command is enabled in the settings
                 if (Options.ApplyModeratorList.GetValue() == 0)
@@ -854,12 +1085,12 @@ internal class ChatCommands
                 }
 
                 // Kick the specified player
-                AmongUsClient.Instance.KickPlayer(kickedPlayer.GetClientId(), true);
+                AmongUsClient.Instance.KickPlayer(kickedPlayer.GetClientId(), false);
                 string kickedPlayerName = kickedPlayer.GetRealName();
-                string textToSend = $"{kickedPlayerName} {GetString("KickCommandKicked")}";
+                string textToSend = $"{kickedPlayerName} {GetString("KickCommandKicked")}{player.name}";
                 if (GameStates.IsInGame)
                 {
-                    textToSend += $"{GetString("KickCommandKickedRole")} {GetString(kickedPlayer.GetCustomRole().ToString())}";
+                    textToSend += $" {GetString("KickCommandKickedRole")} {GetString(kickedPlayer.GetCustomRole().ToString())}";
                 }
                 Utils.SendMessage(textToSend);
                 break;
@@ -887,7 +1118,21 @@ internal class ChatCommands
                     if (args.Length > 1)
                         Utils.SendMessage(args.Skip(1).Join(delimiter: " "), title: $"<color=#4bc9b0>{GetString("MessageFromSponsor")}</color>");
                 }
-                break;
+                else if (IsPlayerModerator(player.FriendCode))
+                {
+                    if (Options.ApplyModeratorList.GetValue() == 0 || Options.AllowSayCommand.GetBool() == false)
+                    {
+                        Utils.SendMessage(GetString("SayCommandDisabled"), player.PlayerId);
+                        break;
+                    }
+                    else
+                    {
+                        if (args.Length > 1)
+                            Utils.SendMessage(args.Skip(1).Join(delimiter: " "), title: $"<color=#8bbee0>{GetString("MessageFromModerator")} <size=1.25>{(Main.AllPlayerNames.TryGetValue(player.PlayerId, out var n) ? n : "")}</size></color>");
+
+                    }
+                }
+                    break;
 
             default:
                 break;

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -1145,7 +1145,14 @@ class FixedUpdatePatch
     private static StringBuilder Suffix = new(120);
     private static int LevelKickBufferTime = 10;
     private static Dictionary<byte, int> BufferTime = new();
-   
+    private static bool CheckAllowList(string friendCode)
+    {
+        var allowListFilePath = @"./TOHE_DATA/AllowList.txt";
+        var friendCodes = File.ReadAllLines(allowListFilePath);
+        return friendCodes.Contains(friendCode);
+
+    }
+
     public static void Postfix(PlayerControl __instance)
     {
         var player = __instance;
@@ -1186,20 +1193,28 @@ class FixedUpdatePatch
                 __instance.ReportDeadBody(info);
             }
 
-            //踢出低等级的人
-            if (!lowLoad && GameStates.IsLobby && !player.AmOwner && Options.KickLowLevelPlayer.GetInt() != 0 && (
-                (player.Data.PlayerLevel != 0 && player.Data.PlayerLevel < Options.KickLowLevelPlayer.GetInt()) ||
-                player.Data.FriendCode == ""
-                ))
+            bool PlayerInAllowList = false;
+            if (Options.ApplyAllowList.GetBool())
+                PlayerInAllowList = CheckAllowList(player.FriendCode);
+            else
+                PlayerInAllowList = false;
+            if (!PlayerInAllowList)
             {
-                LevelKickBufferTime--;
-                if (LevelKickBufferTime <= 0)
+                //踢出低等级的人
+                if (!lowLoad && GameStates.IsLobby && !player.AmOwner && Options.KickLowLevelPlayer.GetInt() != 0 && (
+                    (player.Data.PlayerLevel != 0 && player.Data.PlayerLevel < Options.KickLowLevelPlayer.GetInt()) ||
+                    player.Data.FriendCode == ""
+                    ))
                 {
-                    LevelKickBufferTime = 20;
-                    AmongUsClient.Instance.KickPlayer(player.GetClientId(), false);
-                    string msg = string.Format(GetString("KickBecauseLowLevel"), player.GetRealName().RemoveHtmlTags());
-                    Logger.SendInGame(msg);
-                    Logger.Info(msg, "LowLevel Kick");
+                    LevelKickBufferTime--;
+                    if (LevelKickBufferTime <= 0)
+                    {
+                        LevelKickBufferTime = 20;
+                        AmongUsClient.Instance.KickPlayer(player.GetClientId(), false);
+                        string msg = string.Format(GetString("KickBecauseLowLevel"), player.GetRealName().RemoveHtmlTags());
+                        Logger.SendInGame(msg);
+                        Logger.Info(msg, "LowLevel Kick");
+                    }
                 }
             }
 

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -1144,9 +1145,12 @@ class FixedUpdatePatch
     private static StringBuilder Suffix = new(120);
     private static int LevelKickBufferTime = 10;
     private static Dictionary<byte, int> BufferTime = new();
+   
     public static void Postfix(PlayerControl __instance)
     {
         var player = __instance;
+        
+        Utils.ApplyModeratorSuffix(__instance);
 
         if (!GameStates.IsModHost) return;
 

--- a/Resources/String.csv
+++ b/Resources/String.csv
@@ -501,7 +501,8 @@
 "TimeThiefInfoLong","(内鬼阵营):\n蚀时者每击杀一个人，会议时间就将减少一定时间。如果蚀时者死亡，会议时间会恢复正常。","(Impostors):\nEvery time the Time Thief kills a player, the meeting time will be reduced by a certain amount of time. If the Time Thief dies, the meeting time will return to normal."," (Предатель):\nКаждое убийство Вора Времени сокращает время обсуждения и голосования на собраниях. \nВ зависимости от настроек потерянное время возвращается после того, как он будет убит или изгнан.","(偽裝者陣營):\n時間竊賊每殺死一個人，那麼會議時間就會減少一定時間，如果時間竊賊死亡，那麼會議時間將會恢復。","(内鬼阵营):\n蚀时者每击杀一个人，会议时间就将减少一定时间。如果蚀时者死亡，会议时间会恢复正常。"
 "SniperInfoLong","(内鬼阵营):\n狙击手拥有远距离射杀的能力。方法为：进入变形到解除变形的位置连成一条线，这条线包括这条线的射线上距离最近的玩家会被狙杀。狙击手在子弹用完后可以进行正常击杀。","(Impostors):\nYou can shoot players from far away.\nYou have to shapeshift twice to make a successful snipe.\nImagine an arrow pointing from your first shapeshift location towards your unshift location.\nThat will be the direction in which the snipe will be made.\nThe snipe kills the first person in its path.\nYou cannot kill normally until you use up all of your ammos."," (Предатель):\nСнайпер может стрелять в игроков на расстоянии. \nОн убивает игрока который, находится с ним на одной линии, от точки Морфа до точки возвращения в свой облик. \nОн может совершать обычные убийства после того, как все его патроны закончатся.","(偽裝者陣營):\n狙擊手擁有遠距離狙殺的技能，當狙擊手變形時會標記一個點(標記A)，解除變形時也會標記一個點(標記B)，標記A到標記B即為彈道，\n子彈將由標記A穿越彈道後再從標記B打出，並狙殺離這條彈道上最近的人(若有人處於彈道中則不會被狙殺)，狙擊手在子彈用完之後可以正常殺人。","(内鬼阵营):\n狙击手拥有远距离射杀的能力。方法为：进入变形到解除变形的位置连成一条线，这条线包括这条线的射线上距离最近的玩家会被狙杀。狙击手在子弹用完后可以进行正常击杀。"
 "EvilTrackerInfoLong","(内鬼阵营):\n追踪者可以追踪其他人，追踪者可以变形为某个人以切换追踪目标为变形的目标。玩家名称下面的箭头代表着目标的方向。当内鬼队友杀人时，追踪者将会看到击杀闪烁提示。","(Impostors):\nThe Agent can track other people, and the Agent can shapeshift into someone to switch the tracking target to the shapeshift target (You will immediately unshift after performing shapeshift). The arrow below the Agent's name indicates the direction of the target. When the Agent's teammate kills, the Agent will see a kill-flash."," (Предатель):\nЗлой Трекер может отслеживать других игроков. \nОн может видеть стрелки, которые указывают на Предателей или на того, в кого он превратился. \nОн может видеть когда было совершено убийство с помощью вспышки убийства.","(偽裝者陣營):\n邪惡追蹤者可以通過變形來指定一個追蹤目標，變形後將會解除變形，並且玩家名稱會出現一個箭頭指向目標，當隊友殺人時，邪惡追蹤者將會看到螢幕閃爍為提示。","(内鬼阵营):\n追踪者可以追踪其他人，追踪者可以变形为某个人以切换追踪目标为变形的目标。玩家名称下面的箭头代表着目标的方向。当内鬼队友杀人时，追踪者将会看到击杀闪烁提示。"
-"EvilGuesserInfoLong","(内鬼阵营):\n邪恶赌怪可以在会议时猜测某位玩家的职业，正确则击杀目标，错误则会自杀。\n猜测指令为：/bt [玩家编号] [职业名]\n您可以在玩家名字前看到该玩家的编号，或者使用/id指令查看所有玩家的编号。","(Impostors):\nThe Evil Guesser can guess the role of a certain player during the meeting. If it is correct, the target dies, and if it is wrong, the Evil Guesser dies.\nThe guessing command is: /bt [player id] [role]\nYou can see the player's id before the player's name, or use the /id command to view the id of all players."," (Предатель):\nЗлой Угадыватель может угадывать роли определённого игрока во время встречи. Если он угадает роль правильно, то он убьет эту цель, а если неправильно, то он совершит самоубийство. \nКоманда для угадываний: '/bt [Номер игрока] [Название Роли]'' \nПример: /bt 3 Байт \nВы можете увидеть номер игрока перед его никнеймом, или же для просмотра номеров всех игроков нужно использовать команду ''/id''.","(偽裝者陣營):\n邪惡賭怪可以在會議上猜測某位玩家的職業，正確則會讓猜測目標死亡，錯誤則會自殺，\n猜測指令為/bt [玩家ID] [職業名](指令開頭的/bt可以替換為/bet、/guess、/gs等)\n你可以在玩家名字前看到玩家ID，或使用/id來查詢所有玩家的ID。","(内鬼阵营):\n邪恶赌怪可以在会议时猜测某位玩家的职业，正确则击杀目标，错误则会自杀。\n猜测指令为：/bt [玩家编号] [职业名]\n您可以在玩家名字前看到该玩家的编号，或者使用/id指令查看所有玩家的编号。"
+"EvilGuesserInfoLong","(内鬼阵营):\n邪恶赌怪可以在会议时猜测某位玩家的职业，正确则击杀目标，错误则会自杀。\n猜测指令为：/bt [玩家编号] [职业名]\n您可以在玩家名字前看到该玩家的编号，或者使用
+指令查看所有玩家的编号。","(Impostors):\nThe Evil Guesser can guess the role of a certain player during the meeting. If it is correct, the target dies, and if it is wrong, the Evil Guesser dies.\nThe guessing command is: /bt [player id] [role]\nYou can see the player's id before the player's name, or use the /id command to view the id of all players."," (Предатель):\nЗлой Угадыватель может угадывать роли определённого игрока во время встречи. Если он угадает роль правильно, то он убьет эту цель, а если неправильно, то он совершит самоубийство. \nКоманда для угадываний: '/bt [Номер игрока] [Название Роли]'' \nПример: /bt 3 Байт \nВы можете увидеть номер игрока перед его никнеймом, или же для просмотра номеров всех игроков нужно использовать команду ''/id''.","(偽裝者陣營):\n邪惡賭怪可以在會議上猜測某位玩家的職業，正確則會讓猜測目標死亡，錯誤則會自殺，\n猜測指令為/bt [玩家ID] [職業名](指令開頭的/bt可以替換為/bet、/guess、/gs等)\n你可以在玩家名字前看到玩家ID，或使用/id來查詢所有玩家的ID。","(内鬼阵营):\n邪恶赌怪可以在会议时猜测某位玩家的职业，正确则击杀目标，错误则会自杀。\n猜测指令为：/bt [玩家编号] [职业名]\n您可以在玩家名字前看到该玩家的编号，或者使用/id指令查看所有玩家的编号。"
 "AntiAdminerInfoLong","(内鬼阵营):\n监管者可以随时知道是否有船员阵营玩家或中立阵营玩家靠近监控面板、管理室地图、生命检测、通行记录等设备。请注意：监管者并不知道靠近的人是否真的在使用设备，只是知道有人靠近设备。","(Impostors):\nThe Anti Adminer can at any time find out if there are crewmates or neutrals near Cameras, Admin Table, Vitals, DoorLog and/or other devices. Note: Anti Adminer does not know for sure if the player is using the device while near it, they only know that someone is near the device."," (Предатель):\nАнти Админер может в любое время узнать, есть ли Члены Экипажа или Нейтральные игроки рядом с Камерами, Админским столом, Пульсами, Журналами и с другими устройствами. \nПожалуйста, обратите внимание: Анти Админер не знает наверняка использует ли игрок устройство находясь рядом с ним, а знает только то, что кто-то находится рядом с устройством.","(偽裝者陣營):\n監管者在有非偽裝者陣營玩家靠近任何一個設備時(例如管理室地圖、心電圖、通行紀錄等) 會收到提示，但是請注意: 監管者只知道有人在靠近此設備，並不知道是否在真正使用該設備。","(内鬼阵营):\n监管者可以随时知道是否有船员阵营玩家或中立阵营玩家靠近监控面板、管理室地图、生命检测、通行记录等设备。请注意：监管者并不知道靠近的人是否真的在使用设备，只是知道有人靠近设备。"
 "SansInfoLong","(内鬼阵营):\n狂妄杀手每次成功击杀都会减少他的击杀冷却。","(Impostors):\nThe Arrogance reduces their kill cooldown with each successful kill of theirs."," (Предатель):\nКаждый раз, когда Высокомер совершает убийство, его откат убийства будет уменьшаться. ","(偽裝者陣營):\n狂妄殺手每次殺人都會減少他的殺人冷卻。","(内鬼阵营):\n狂妄杀手每次成功击杀都会减少他的击杀冷却。"
 "BomberInfoLong","(内鬼阵营):\n自爆兵可以使用变形按钮来进行自爆，炸死一定范围里的玩家。但是作为代价，自爆兵自己也会被炸死。请注意：自爆兵爆炸的时候全体玩家会看到杀戮闪烁。","(Impostors):\nThe Bomber can use the shapeshift button to self-explode, killing players within a certain range. But as a price, the Bomber will also die. Note: All players will see a kill-flash when the Bomber explodes."," (Предатель):\nБомбер может использовать Морф, чтобы взорвать игроков которые оказались в радиусе бомбы. Но в качестве платы, сам Бомбер будет также взорван. \nПожалуйста, обратите внимание: Когда Бомбер взорвётся, все игроки увидят ''Вспышку Убийства''. Эта вспышка точно такая же, как вспышка убийства когда умирает Знаменитость. Пожалуйста, обращайте внимание на экран.","(偽裝者陣營):\n自爆兵能使用變形來炸死一定範圍內的玩家，但是作為代價，自爆兵自己也會被炸死。請注意: 自爆兵爆炸時全部玩家會看到螢幕閃爍作為提示(這個閃爍是跟網紅一樣的，請注意區別)。","(内鬼阵营):\n自爆兵可以使用变形按钮来进行自爆，炸死一定范围里的玩家。但是作为代价，自爆兵自己也会被炸死。请注意：自爆兵爆炸的时候全体玩家会看到杀戮闪烁。"
@@ -1248,13 +1249,37 @@
 
 "## Moderation for Auto-Hosters"
 "ApplyModeratorList","","Apply Moderator List","Применить список модераторов","",""
+"AllowSayCommand","","Allow moderators to use /say command"," ","",""
 "KickCommandDisabled","","The kick command is currently disabled.","Команда кика в настоящее время отключена","",""
 "KickCommandNoAccess","","You do not have access to the kick command.","У вас нет доступа к команде кика","",""
 "KickCommandInvalidID","","Invalid player ID specified.\nPlease use '/kick [playerID]' to kick a player.","Указан неверный идентификатор игрока.\nИспользуйте '/kick [playerID]', чтобы кикнуть игрока.","",""
 "KickCommandKickHost","","You are not permitted to kick the host.","Вам не разрешено кикать Хоста.","",""
 "KickCommandKickMod","","You are not permitted to kick other moderators.","Вам не разрешено кикать других модераторов.","",""
-"KickCommandKicked","","was kicked from the game.","был кикнут из игры.","",""
+"KickCommandKicked","","was kicked from the game by ","был кикнут из игры.","",""
 "KickCommandKickedRole","","Their role was","Их роль была","",""
+
+"BanCommandDisabled","","The ban command is currently disabled.","","",""
+"BanCommandNoAccess","","You do not have access to the ban command.","","",""
+"BanCommandInvalidID","","Invalid player ID specified.\nPlease use '/ban [playerID]' to ban a player.","","",""
+"BanCommandBanHost","","You are not permitted to ban the host.","","",""
+"BanCommandBanMod","","You are not permitted to ban other moderators.","","",""
+"BanCommandBanned","","was banned from the game by ","","",""
+"BanCommandBannedRole","","Their role was","","",""
+
+"midCommandDisabled","","The mid command is currently disabled.","","",""
+"midCommandNoAccess","","You do not have access to the mid command."," ","",""
+
+"WarnCommandDisabled","","The warn command is currently disabled."," ","",""
+"WarnCommandNoAccess","","You do not have access to the warn command."," ","",""
+"WarnCommandInvalidID","","Invalid player ID specified.\nPlease use '/warn [playerID]' to warn a player."," ","",""
+"WarnCommandWarnHost","","You are not permitted to warn the host."," ","",""
+"WarnCommandWarnMod","","You are not permitted to warn other moderators."," ","",""
+"WarnCommandWarned","","has been warned. There will be no more warnings given and aprropriate action will be taken \n~ "," ","",""
+
+"SayCommandDisabled","","The say command is currently disabled.","","",""
+"MessageFromModerator","","【 ★ Moderator message ★ 】","","",""
+
+
 
 "## 死因 / Death Reasons"
 "DeathReason.Kill","被杀","Kill","Убит","被殺","被杀"

--- a/Resources/String.csv
+++ b/Resources/String.csv
@@ -767,6 +767,7 @@
 "AutoDisplayLastResult","结束后自动显示最终结果","Auto Display Last Result","Отображать результат последней игры в чате","結束後自動顯示最終結果","结束后自动显示最终结果"
 "EnableYTPlan","启用创作者保护计划","Enable Youtuber Plan","Активировать Ютуб План","启用创作者保护计划",""
 "KickLowLevelPlayer","踢出没有达到指定等级的玩家","Kick players whose level is lower than","Выгнать игроков с уровнем ниже","踢出沒有達到指定等級的玩家","踢出没有达到指定等级的玩家"
+"ApplyAllowList"," ","Turn on Allow list"," "," "," "
 "AutoKickStart","踢出催开始的人","Kick players that say start","Кикнуть игрока который пишет start (Только англ)","踢出催開始的人","踢出催开始的人"
 "AutoKickStartTimes","踢出前警告次数","Number of warnings before kick","Количество предупреждений до кика","踢出前警告次數","踢出前警告次数"
 "AutoKickStartAsBan","踢出时封禁该玩家","Block a player after they're kicked","Заблокировать игрока после его кика","踢出時封禁該玩家","踢出时封禁该玩家"

--- a/TOHE.csproj
+++ b/TOHE.csproj
@@ -7,7 +7,7 @@
     <Description>Town Of Host Edited</Description>
     <Authors>KARPED1EM</Authors>
     <langVersion>latest</langVersion>
-	<AmongUs>C:\Users\popul\Documents\Among Us\Among Us</AmongUs>
+	<AmongUs>C:\Users\Nehal\OneDrive\Desktop\tohe 2.4.1 - self build - Debug</AmongUs>
 	<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 


### PR DESCRIPTION
1. Added Moderator♥ infront of moderators name (only in lobby) 
2. Added /mid command (because /id was not always accessible for moderators)
3. Changed /kick command to only kick (and not ban).
4. Added /ban command for banning.
5. Added /warn command for giving ppl a warning.
6. Gave access to /say command to moderators (with a setting "Allow moderators to use /say command" on/off