### PR TITLE
Deathpact fix arrows leading to other players in pact

### DIFF
--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -1204,12 +1204,10 @@ public static class Utils
             {
             SelfSuffix.Append(EvilTracker.GetTargetArrow(seer, seer));
             }
-            if (seer.Is(CustomRoles.Deathpact) && !isForMeeting)
-            {
-            SelfSuffix.Append(Deathpact.GetDeathpactPlayerArrow(seer));
-            }
 
-            
+            SelfSuffix.Append(Deathpact.GetDeathpactPlayerArrow(seer));
+
+
 
             //KB自身名字后缀
 

--- a/Roles/Impostor/Deathpact.cs
+++ b/Roles/Impostor/Deathpact.cs
@@ -223,7 +223,7 @@ namespace TOHE.Roles.Impostor
 
         public static bool IsInDeathpact(byte deathpact, PlayerControl target)
         {
-            return PlayersInDeathpact[deathpact].Any(a => a.PlayerId == target.PlayerId);
+            return PlayersInDeathpact.ContainsKey(deathpact) && PlayersInDeathpact[deathpact].Any(a => a.PlayerId == target.PlayerId);
         }
 
         public static string GetDeathpactString(PlayerControl player)


### PR DESCRIPTION
somehow you added this role check which prevented the players from getting arrows