### PR TITLE
Fix Medic Mark

### DIFF
--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -1724,7 +1724,7 @@ public static class Utils
                 {
                     TargetMark.Append(ColorString(GetRoleColor(CustomRoles.Medic), " ●"));
                 }
-                else if (seer.Data.IsDead && Medic.InProtect(target.PlayerId))
+                else if (seer.Data.IsDead && Medic.InProtect(target.PlayerId) && !seer.Is(CustomRoles.Medic))
                 {
                     TargetMark.Append(ColorString(GetRoleColor(CustomRoles.Medic), " ●"));
                 }

--- a/Patches/MeetingHudPatch.cs
+++ b/Patches/MeetingHudPatch.cs
@@ -1003,7 +1003,7 @@ class MeetingHudStartPatch
             if (seer.Is(CustomRoles.Medic) && (Medic.InProtect(target.PlayerId) || Medic.TempMarkProtected == target.PlayerId) && (Medic.WhoCanSeeProtect.GetInt() == 0 || Medic.WhoCanSeeProtect.GetInt() == 1))
                 sb.Append(Utils.ColorString(Utils.GetRoleColor(CustomRoles.Medic), " ●"));
 
-            if (seer.Data.IsDead && Medic.InProtect(target.PlayerId))
+            if (seer.Data.IsDead && Medic.InProtect(target.PlayerId) && !seer.Is(CustomRoles.Medic))
                 sb.Append(Utils.ColorString(Utils.GetRoleColor(CustomRoles.Medic), " ●"));
 
             //赌徒提示

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -1952,7 +1952,7 @@ class FixedUpdatePatch
                 if (seer.Is(CustomRoles.Medic) && (Medic.InProtect(target.PlayerId) || Medic.TempMarkProtected == target.PlayerId) && (Medic.WhoCanSeeProtect.GetInt() == 0 || Medic.WhoCanSeeProtect.GetInt() == 1))
                     Mark.Append($"<color={Utils.GetRoleColorCode(CustomRoles.Medic)}> ●</color>");
 
-                if (seer.Data.IsDead && Medic.InProtect(target.PlayerId))
+                if (seer.Data.IsDead && Medic.InProtect(target.PlayerId) && !seer.Is(CustomRoles.Medic))
                     Mark.Append($"<color={Utils.GetRoleColorCode(CustomRoles.Medic)}> ●</color>");
 
                 Mark.Append(Totocalcio.TargetMark(seer, target));


### PR DESCRIPTION
Fix a bug where a dead Medic sees two shield marks:

![image](https://github.com/Loonie-Toons/TOHE-Restored/assets/104814436/37eef95b-1d7f-4d8f-8082-bec5f76a0866)
